### PR TITLE
Update correct x2 register value in ARM64 posts

### DIFF
--- a/arm64-el0-el1-switching/index.md
+++ b/arm64-el0-el1-switching/index.md
@@ -51,7 +51,7 @@ Here's a simple EL0 code snippet to trigger a system call:
 mov x8, #64           // syscall number for write (Linux ARM64)
 mov x0, #1            // file descriptor (stdout = 1)
 adr x1, print_msg     // pointer to message
-mov x2, #12           // length of message
+mov x2, #38           // length of message
 svc #0                // trigger system call to EL1
 
 print_msg:

--- a/arm64-exception-levels/index.md
+++ b/arm64-exception-levels/index.md
@@ -52,7 +52,7 @@ Below code snippet makes a system call request to EL1 from EL0 (in AArch64 assem
 mov x8, #64    // Syscall number for 'write'
 mov x0, #1     // File descriptor (stdout)
 ldr x1, =msg   // Pointer to the message string.
-mov x2, #13    // Length of message
+mov x2, #38    // Length of message
 svc #0         // System call to EL1
 
 msg:


### PR DESCRIPTION
I made this fix to avoid confusion, as it is incorrectly mentioned as 12/13 in the blog posts. 